### PR TITLE
Add JETBRAINS_ANNOTATIONS conditional compilation symbol

### DIFF
--- a/Sources/MiniGuard/MiniGuard.csproj
+++ b/Sources/MiniGuard/MiniGuard.csproj
@@ -12,6 +12,12 @@
     <Description>A minimalistic guard library with Resharper contract annotations</Description>
     <Copyright>Copyright © 2017</Copyright>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;JETBRAINS_ANNOTATIONS</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE;JETBRAINS_ANNOTATIONS</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" />
   </ItemGroup>


### PR DESCRIPTION
JETBRAINS_ANNOTATIONS conditional compilation symbol has been added for all configurations to the project based on this article:

https://resharper-support.jetbrains.com/hc/en-us/community/posts/115000349164-JetBrains-Annotations-not-working-from-referenced-NuGet-package

- It solves the issue mentioned here: https://github.com/thedmi/MiniGuard/issues/1