### PR TITLE
MiniGuard.Test project update to net5.0

### DIFF
--- a/Sources/MiniGuard.Test/MiniGuard.Test.csproj
+++ b/Sources/MiniGuard.Test/MiniGuard.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
I have noticed during a build that there is a deprecation warning, that net core 2.0 is obsolete. Therefore I have updated the Test project to net 5.

If you feel like that this is too much then I would still suggest updating the test project to net core 3.1.